### PR TITLE
MS Windows port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+.vs/
 build/
 build_cmake/
 .cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,11 @@ add_executable(neural_network
     src/utils/ConfigParser.cpp
 )
 
-# Link filesystem library (C++17)
-target_link_libraries(neural_network PRIVATE stdc++fs)
+if (WIN32)
+else()
+  # Link filesystem library (C++17)
+  target_link_libraries(neural_network PRIVATE stdc++fs)
+endif()
 
 add_executable(test_tensor
     tests/test_tensor.cpp


### PR DESCRIPTION
Tested with Visual Studio 2022.
Actually, if to launch from VS, and Visual Studio builds binary inside folder `out\build\x64-Debug\neural_network.exe`, I also needed this code snippet, not included in PR, to set current working directory two levels up:
```C++
int main() {
#ifdef _WIN32
  namespace fs = std::filesystem;
  fs::path cwd = fs::current_path();
  fs::path newCwd = cwd.parent_path().parent_path();
  fs::current_path(newCwd);
#endif
```
That is optional, as README.md uses different build command. Leaving it here if someone needs.
Also I would remove compiled binary `neural_network` from repo as it is platform-dependent.